### PR TITLE
Make Calico IPv6 pod CIDR match what we've told to Kubernetes

### DIFF
--- a/calico/calico-3.10.0-dualstack.yaml
+++ b/calico/calico-3.10.0-dualstack.yaml
@@ -629,7 +629,7 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"
             - name: CALICO_IPV6POOL_CIDR
-              value: "fd00:10:244::/16"
+              value: "fd00:10:244::/64"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -797,4 +797,3 @@ metadata:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-

--- a/calico/calico-etcd-3.10.0-dualstack.yaml
+++ b/calico/calico-etcd-3.10.0-dualstack.yaml
@@ -324,7 +324,7 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"
             - name: CALICO_IPV6POOL_CIDR
-              value: "fd00:10:244::/16"
+              value: "fd00:10:244::/64"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -526,5 +526,3 @@ metadata:
 
 ---
 # Source: calico/templates/kdd-crds.yaml
-
-


### PR DESCRIPTION
There was a prefix len error, and "fd00:10:244::/16" was in fact
behaving as "fd00::/16".